### PR TITLE
Restrict with and property interceptors

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ module.exports = {
             'WhileStatement',
             'SwitchStatement',
             'VariableDeclaration[kind="var"]',
-            'VariableDeclaration[kind="let"]'
+            'VariableDeclaration[kind="let"]',
+            'WithStatement',
+            'MethodDefinition[kind="get"]',
+            'MethodDefinition[kind="set"]'
         ],
         'semi': ['error', 'never'],
         'capitalized-comments': ['off'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-rung",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Default coding style for Rung.",
   "main": "index.js",
   "author": "Paulo Henrique Cuchi <paulo.cuchi@gmail.com>",


### PR DESCRIPTION
This pull-requests adds restriction to:

- `with` statement, as long as it has been deprecated years ago. You probably don't even know it, and that's good;
- `get` and `set` keywords. Yes, keywords, not names. They are implicit effect and make property access magical and non-deterministic. `x.y` may be `1` and later `x.y` may be `2`. That's weird. 